### PR TITLE
L25/efficient thread blocking

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,14 +24,14 @@ arm-none-eabi-gcc -O0 -g -Wall -mcpu=cortex-m4+nofp -mthumb -c -o build/miros.o 
 arm-none-eabi-gcc -O0 -g -Wall -mcpu=cortex-m4+nofp -mthumb -c -o build/main.o src/main.c
 # arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o build/main.elf build/startup.o build/bsp.o build/delay.o build/system_stm32f4xx.o build/main.o
 
-arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o build/main.elf build/startup.o build/bsp.o build/delay.o build/miros.o build/main.o
-arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o main.elf build/startup.o build/bsp.o build/delay.o build/miros.o build/main.o
+arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o build/main.elf build/startup.o build/bsp.o build/delay.o build/system_stm32f4xx.o build/miros.o build/main.o
+arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o main.elf build/startup.o build/bsp.o build/delay.o build/system_stm32f4xx.o build/miros.o build/main.o
 
 
 # arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o build/main.elf build/startup.o build/bsp.o build/delay.o build/miros.o build/system_stm32f4xx.o build/main.o
 # arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o main.elf build/startup.o build/bsp.o build/delay.o build/miros.o build/system_stm32f4xx.o build/main.o
 
-arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o build/main.elf build/startup.o build/bsp.o build/delay.o build/miros.o build/main.o
+arm-none-eabi-ld -Map build/main.map -T startup/linker.ld -o build/main.elf build/startup.o build/bsp.o build/delay.o build/system_stm32f4xx.o build/miros.o build/main.o
 
 # arm-none-eabi-ld -T linker.ld -o main.elf delay.o main.o
 arm-none-eabi-objcopy -O binary build/main.elf build/main.bin

--- a/core/miros/miros.c
+++ b/core/miros/miros.c
@@ -41,9 +41,25 @@ OSThread *OS_thread[32 + 1]; /* array of threads */
 uint8_t OS_threadNum; /* number of threads started so far */
 uint8_t OS_currIndex; /* current thread index for round-robin */
 
-void OS_init(void) {
+OSThread idle_thread;
+
+void main_idle() {
+    while(1) {
+        OS_on_idle();
+    }
+}
+
+
+
+void OS_init(void *stkSto, uint32_t stkSize) {
     /* set the PendSV interrupt priority to the lowest level 0xFF */
     *(uint32_t volatile *)0xE000ED20 |= (0xFFU << 16);
+
+    OSThread_start(&idle_thread,
+    &main_idle,
+    stkSto,
+    stkSize
+    );
 }
 
 void OS_sched(void) {

--- a/core/miros/miros.c
+++ b/core/miros/miros.c
@@ -160,6 +160,11 @@ void OSThread_start(
     Q_ASSERT(OS_threadNum < Q_DIM(OS_thread));
 
     OS_thread[OS_threadNum] = me;
+    /* Make thread ready to run. Except for the idle thread of course */
+    if (OS_threadNum > 0) {
+        OS_ready_set |= (1 << (OS_threadNum - 1));
+    }
+
     ++OS_threadNum;
 }
 

--- a/include/bsp.h
+++ b/include/bsp.h
@@ -31,6 +31,12 @@ void Q_onError(char const* module, int id);
 //Base GPIOB register 0x4002 0400 + offset 0x14 to find GPIOx_ODR
 #define GPIOx_ODR (*((unsigned int *)(0x40020414)))
 
+//Base GPIOA register 0x4002 0000 + offset 0x00 to find GPIOA_MODER
+#define GPIOA_MODER (*((unsigned int *)(0x40020000)))
+
+//Base GPIOA register 0x4002 0000 + offset 0x14 to find GPIOx_ODR
+#define GPIOA_ODR (*((unsigned int *)(0x40020014)))
+
 /**
  * @brief Implements a delay
  * @author @Mike-Kimani

--- a/include/miros.h
+++ b/include/miros.h
@@ -8,6 +8,7 @@ typedef struct
 {
     void *sp; /*Stack pointer*/
     /*... Other thread attributes*/
+
 } OSThread;
 
 /* Function pointer to function run in thread */
@@ -16,7 +17,12 @@ typedef void (*OSThreadHandler)();
 /**
  * @brief Initialize thread handling setting
  */
-void OS_init(void);
+void OS_init(void *stkSto, uint32_t stkSize);
+/**
+ * @brief Callback to run idle thread
+ */
+void OS_on_idle();
+
 /**
  * @brief Set the bit for PendSV to be triggered if next thread is different with current thread
  * @attention Function must be called with interrupts disabled

--- a/include/miros.h
+++ b/include/miros.h
@@ -32,6 +32,11 @@ void OS_sched(void);
  * @brief Callback to configure  and start interrupts
  */
 void OS_onStartup(void);
+/* blocking delay */
+void OS_delay(uint32_t ticks);
+/* processing all thread timeouts */
+void OS_tick(void);
+
 /**
  * @brief Transfer control to the RTOS to run threads
  */

--- a/include/miros.h
+++ b/include/miros.h
@@ -32,9 +32,14 @@ void OS_sched(void);
  * @brief Callback to configure  and start interrupts
  */
 void OS_onStartup(void);
-/* blocking delay */
+/**
+ * @brief Set number of clock ticks needed to unblock the calling thread
+ * @param ticks
+ */
 void OS_delay(uint32_t ticks);
-/* processing all thread timeouts */
+/**
+ * @brief Process timout for all threads
+ */
 void OS_tick(void);
 
 /**

--- a/include/miros.h
+++ b/include/miros.h
@@ -8,7 +8,7 @@ typedef struct
 {
     void *sp; /*Stack pointer*/
     /*... Other thread attributes*/
-
+    uint32_t timeout;
 } OSThread;
 
 /* Function pointer to function run in thread */

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -67,9 +67,9 @@ void BSP_init() {
 void BSP_ledInit() {
     //Bitwise OR the second bit of RCC_AHB1ENR with 1 to enable GPIOB_EN CLOCK
     RCC_AH1BEN |= (0b01 << 1);
-    //Bitwise AND the 16th bit and 2nd bit of GPIOB_MODER with 0 - CONFIG PB7 & PB0 as output
+    //Bitwise AND the 16th bit and 2nd bit of GPIOB_MODER with 0 - CONFIG PB7 & PB0 & PB14 as output
     GPIOB_MODER &= ((0b00 << 15) | (0b00 << 1) |(0b00 << 29));
-    //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 as output
+    //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 & PB14 as output
     GPIOB_MODER |= ((0b01 << 14) | (0b01 << 0) | (0b01 << 28));
 }
 

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -24,8 +24,8 @@ void OS_onStartup(void) {
 void OS_on_idle(void) {
     // GPIOx_ODR |= (0b01 << 14);
     // GPIOx_ODR &= ~(0b01 << 14);
-    // GPIOA_ODR |= (0b01 << 12);
-    // GPIOA_ODR &= ~(0b01 << 12);
+    GPIOA_ODR |= (0b01 << 12);
+    GPIOA_ODR &= ~(0b01 << 12);
 
 }
 
@@ -79,10 +79,10 @@ void BSP_ledInit() {
     GPIOB_MODER &= ((0b00 << 15) | (0b00 << 1) | (0b00 << 29) | (0b00 << 3));
     //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 & PB14 & PB1 as output
     GPIOB_MODER |= ((0b01 << 14) | (0b01 << 0) | (0b01 << 28) | (0b01 << 2));
-    /* Bitwise AND the second bit of GPIOA_MODER with 0 */
-    GPIOA_MODER &= (0b00 << 13);
-    /* Bite wise OR the 1st bit of GPIOA_MODER with 1*/
-    GPIOA_MODER |= (0b01 << 12);
+    /* Bitwise AND the 15th of GPIOA_MODER with 0 */
+    // GPIOA_MODER &= (0b00 << 15);
+    /* Bite wise OR the 14th bit of GPIOA_MODER with 1*/
+    GPIOA_MODER |= (0b01 << 24);
 }
 
 void BSP_greenLedToggle() {

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -20,6 +20,9 @@ void OS_onStartup(void) {
     NVIC_SetPriority(SysTick_IRQn, 0U);
 }
 
+void OS_on_idle(void) {
+}
+
 unsigned int volatile l_tickrCtr;
 
 void SysTick_Handler (void) 

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -15,6 +15,7 @@ void Q_onError(char const* module, int id) {
 
 void OS_onStartup(void) {
     SystemCoreClockUpdate();
+    /* For 16MHz clock frequency. This results in BSP_TICKS_PER_SEC SysTick interrupts per sec*/
     SysTick_Config(16000000/BSP_TICKS_PER_SEC);
 
     NVIC_SetPriority(SysTick_IRQn, 0U);

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -22,8 +22,10 @@ void OS_onStartup(void) {
 }
 
 void OS_on_idle(void) {
-    GPIOx_ODR |= (0b01 << 14);
-    GPIOx_ODR &= ~(0b01 << 14);
+    // GPIOx_ODR |= (0b01 << 14);
+    // GPIOx_ODR &= ~(0b01 << 14);
+    // GPIOA_ODR |= (0b01 << 12);
+    // GPIOA_ODR &= ~(0b01 << 12);
 
 }
 
@@ -72,11 +74,15 @@ void BSP_init() {
 
 void BSP_ledInit() {
     //Bitwise OR the second bit of RCC_AHB1ENR with 1 to enable GPIOB_EN CLOCK
-    RCC_AH1BEN |= (0b01 << 1);
+    RCC_AH1BEN |= (0b01 << 1) | (0b01 << 0);
     //Bitwise AND the 16th bit and 2nd bit of GPIOB_MODER with 0 - CONFIG PB7 & PB0 & PB14 & PB1 as output
     GPIOB_MODER &= ((0b00 << 15) | (0b00 << 1) | (0b00 << 29) | (0b00 << 3));
     //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 & PB14 & PB1 as output
     GPIOB_MODER |= ((0b01 << 14) | (0b01 << 0) | (0b01 << 28) | (0b01 << 2));
+    /* Bitwise AND the second bit of GPIOA_MODER with 0 */
+    GPIOA_MODER &= (0b00 << 13);
+    /* Bite wise OR the 1st bit of GPIOA_MODER with 1*/
+    GPIOA_MODER |= (0b01 << 12);
 }
 
 void BSP_greenLedToggle() {

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -22,8 +22,10 @@ void OS_onStartup(void) {
 }
 
 void OS_on_idle(void) {
+    /* @TODO Investigate why this causes irregular thread switching */
     // GPIOx_ODR |= (0b01 << 14);
     // GPIOx_ODR &= ~(0b01 << 14);
+
     GPIOA_ODR |= (0b01 << 12);
     GPIOA_ODR &= ~(0b01 << 12);
 
@@ -80,7 +82,8 @@ void BSP_ledInit() {
     //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 & PB14 & PB1 as output
     GPIOB_MODER |= ((0b01 << 14) | (0b01 << 0) | (0b01 << 28) | (0b01 << 2));
     /* Bitwise AND the 15th of GPIOA_MODER with 0 */
-    // GPIOA_MODER &= (0b00 << 15);
+    /* @TODO Investigate why this bricks flashing with stlink */
+    // GPIOA_MODER &= (0b00 << 25);
     /* Bite wise OR the 14th bit of GPIOA_MODER with 1*/
     GPIOA_MODER |= (0b01 << 24);
 }

--- a/src/bsp.c
+++ b/src/bsp.c
@@ -21,16 +21,21 @@ void OS_onStartup(void) {
 }
 
 void OS_on_idle(void) {
+    GPIOx_ODR |= (0b01 << 14);
+    GPIOx_ODR &= ~(0b01 << 14);
+
 }
 
 unsigned int volatile l_tickrCtr;
 
 void SysTick_Handler (void) 
 {
-    ++l_tickrCtr;
-    
+    GPIOx_ODR |= (0b01 << 1);
+    OS_tick();
+
     __disable_irq();
     OS_sched();
+    GPIOx_ODR &= ~(0b01 << 1);
     __enable_irq();
 } 
 
@@ -67,10 +72,10 @@ void BSP_init() {
 void BSP_ledInit() {
     //Bitwise OR the second bit of RCC_AHB1ENR with 1 to enable GPIOB_EN CLOCK
     RCC_AH1BEN |= (0b01 << 1);
-    //Bitwise AND the 16th bit and 2nd bit of GPIOB_MODER with 0 - CONFIG PB7 & PB0 & PB14 as output
-    GPIOB_MODER &= ((0b00 << 15) | (0b00 << 1) |(0b00 << 29));
-    //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 & PB14 as output
-    GPIOB_MODER |= ((0b01 << 14) | (0b01 << 0) | (0b01 << 28));
+    //Bitwise AND the 16th bit and 2nd bit of GPIOB_MODER with 0 - CONFIG PB7 & PB0 & PB14 & PB1 as output
+    GPIOB_MODER &= ((0b00 << 15) | (0b00 << 1) | (0b00 << 29) | (0b00 << 3));
+    //Bitwise OR the 15th bit and 1st of GPIOB_MODER with 1 - CONFIG PB7 & PB0 & PB14 & PB1 as output
+    GPIOB_MODER |= ((0b01 << 14) | (0b01 << 0) | (0b01 << 28) | (0b01 << 2));
 }
 
 void BSP_greenLedToggle() {

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ void main_blinky1() {
     while (1)
     {
         BSP_greenLedToggle();
-        BSP_Delay(50);
+        OS_delay(50);
     }
 
 }
@@ -25,7 +25,7 @@ void main_blinky2() {
     while (1)
     {
         BSP_blueLedToggle();
-        BSP_Delay(50);
+        OS_delay(50);
     }
 
 }
@@ -34,7 +34,7 @@ OSThread blinky3;
 void main_blinky3() {
     while (1) {
         BSP_redLedToggle();
-        BSP_Delay(50);
+        OS_delay(50);
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -55,10 +55,10 @@ int main() {
                    stack_blinky2,
                    sizeof(stack_blinky2));
     /* fabricate Cortex-M ISR stack for blinky3 */
-    // OSThread_start(&blinky3,
-    //     &main_blinky3,
-    //     stack_blinky3,
-    //     sizeof(stack_blinky3));
+    OSThread_start(&blinky3,
+        &main_blinky3,
+        stack_blinky3,
+        sizeof(stack_blinky3));
 
     OS_run();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -55,10 +55,10 @@ int main() {
                    stack_blinky2,
                    sizeof(stack_blinky2));
     /* fabricate Cortex-M ISR stack for blinky3 */
-    OSThread_start(&blinky3,
-        &main_blinky3,
-        stack_blinky3,
-        sizeof(stack_blinky3));
+    // OSThread_start(&blinky3,
+    //     &main_blinky3,
+    //     stack_blinky3,
+    //     sizeof(stack_blinky3));
 
     OS_run();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -38,9 +38,10 @@ void main_blinky3() {
     }
 }
 
+uint32_t stack_idle_thread[40];
 int main() {
     BSP_init();
-    OS_init();
+    OS_init(stack_idle_thread, sizeof(stack_idle_thread));
     BSP_ledInit();
 
     /* fabricate Cortex-M ISR stack for blinky1 */


### PR DESCRIPTION
Add OS functions to handle blocking of threads.

Blocks threads that are not active from running. This is handled by ticking a timer for the threads outside the threads. When the timer for any thread is done, that thread is unblocked.